### PR TITLE
Add CLI options

### DIFF
--- a/src/CoyoteApi/CoyoteHandler.cs
+++ b/src/CoyoteApi/CoyoteHandler.cs
@@ -167,18 +167,20 @@ namespace Eleia.CoyoteApi
         {
             RemoveXHeaders();
             _logger.LogDebug("Getting new posts");
-            var json = await hc.GetStringAsync($"{Endpoints.PostsApi}/{postId}");
+            var json = await hc.GetStringAsync($"{Endpoints.PostsApi}/{postId}").ConfigureAwait(false);
 
             var result = JsonSerializer.Deserialize<SinglePostApiResult>(json);
 
-            var post = new Post();
-            post.created_at = result.data.created_at;
-            post.forum_id = result.data.forum_id;
-            post.id = result.data.id;
-            post.text = result.data.text;
-            post.topic_id = result.data.topic_id;
-            post.user = result.data.user;
-            post.user_name = result.data.user_name;
+            var post = new Post
+            {
+                created_at = result.data.created_at,
+                forum_id = result.data.forum_id,
+                id = result.data.id,
+                text = result.data.text,
+                topic_id = result.data.topic_id,
+                user = result.data.user,
+                user_name = result.data.user_name
+            };
 
             return post;
         }

--- a/src/CoyoteApi/CoyoteHandler.cs
+++ b/src/CoyoteApi/CoyoteHandler.cs
@@ -157,5 +157,30 @@ namespace Eleia.CoyoteApi
 
             return result.data;
         }
+
+        /// <summary>
+        /// Get single post of a given id from the Coyote API
+        /// </summary>
+        /// <param name="postId">Id of a post to get</param>
+        /// <returns>Single post of a given id</returns>
+        public async Task<Post> GetSinglePost(int postId)
+        {
+            RemoveXHeaders();
+            _logger.LogDebug("Getting new posts");
+            var json = await hc.GetStringAsync($"{Endpoints.PostsApi}/{postId}");
+
+            var result = JsonSerializer.Deserialize<SinglePostApiResult>(json);
+
+            var post = new Post();
+            post.created_at = result.data.created_at;
+            post.forum_id = result.data.forum_id;
+            post.id = result.data.id;
+            post.text = result.data.text;
+            post.topic_id = result.data.topic_id;
+            post.user = result.data.user;
+            post.user_name = result.data.user_name;
+
+            return post;
+        }
     }
 }

--- a/src/CoyoteApi/Post.cs
+++ b/src/CoyoteApi/Post.cs
@@ -44,11 +44,13 @@ namespace Eleia.CoyoteApi
         public Meta meta { get; set; }
     }
 
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class SinglePostApiResult
     {
         public SinglePost data { get; set; }
     }
 
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class SinglePost
     {
         public int id { get; set; }
@@ -61,9 +63,10 @@ namespace Eleia.CoyoteApi
         public User user { get; set; }
         public string text { get; set; }
         public string url { get; set; }
-        public Comment[] comments { get; set; }
+        public IEnumerable<Comment> comments { get; set; }
     }
 
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Comment
     {
         public int id { get; set; }

--- a/src/CoyoteApi/Post.cs
+++ b/src/CoyoteApi/Post.cs
@@ -44,6 +44,38 @@ namespace Eleia.CoyoteApi
         public Meta meta { get; set; }
     }
 
+    public class SinglePostApiResult
+    {
+        public SinglePost data { get; set; }
+    }
+
+    public class SinglePost
+    {
+        public int id { get; set; }
+        public object user_name { get; set; }
+        public int score { get; set; }
+        public int edit_count { get; set; }
+        public int forum_id { get; set; }
+        public int topic_id { get; set; }
+        public DateTime created_at { get; set; }
+        public User user { get; set; }
+        public string text { get; set; }
+        public string url { get; set; }
+        public Comment[] comments { get; set; }
+    }
+
+    public class Comment
+    {
+        public int id { get; set; }
+        public int post_id { get; set; }
+        public int user_id { get; set; }
+        public DateTime created_at { get; set; }
+        public DateTime updated_at { get; set; }
+        public object deleted_at { get; set; }
+        public string text { get; set; }
+        public User user { get; set; }
+    }
+
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Post
     {

--- a/src/Eleia.csproj
+++ b/src/Eleia.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.16" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -118,6 +118,7 @@ namespace Eleia
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "RCS1090:Call 'ConfigureAwait(false)'.", Justification = "Not a library")]
         private async static Task RunOnSet()
         {
             foreach (var item in runSet.Select(async x => await ch.GetSinglePost(x)))
@@ -138,15 +139,15 @@ namespace Eleia
 
             var username = config.GetValue("username", opts.UserName);
             var password = config.GetValue("password", opts.Password);
-            timeBetweenUpdates = config.GetValue("timeBetweenUpdates", opts.TimeBetweenUpdates.HasValue ? opts.TimeBetweenUpdates.Value : 60);
+            timeBetweenUpdates = config.GetValue("timeBetweenUpdates", opts.TimeBetweenUpdates ?? 60);
 
             if (timeBetweenUpdates == 0)
                 opts.RunOnce = true;
 
             nagMessage = config.GetValue("nagMessage", "Hej! Twój post prawdopodobnie zawiera niesformatowany kod. Użyj znaczników ``` aby oznaczyć, co jest kodem, będzie łatwiej czytać. (jestem botem, ta akcja została wykonana automatycznie, prawdopodobieństwo {0})");
 
-            Endpoints.IsDebug = config.GetValue("useDebug4p", opts.UseDebug4p.HasValue ? opts.UseDebug4p.Value : true);
-            postComments = config.GetValue("postComments", opts.PostComments.HasValue ? opts.PostComments.Value : false);
+            Endpoints.IsDebug = config.GetValue("useDebug4p", opts.UseDebug4p ?? true);
+            postComments = config.GetValue("postComments", opts.PostComments ?? false);
 
             var serviceProvider = new ServiceCollection()
                 .AddLogging(builder => builder

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -57,6 +57,7 @@ namespace Eleia
         private static string nagMessage;
 
         private static bool runOnce = false;
+        private static bool configured = false;
 
         public class Options
         {
@@ -85,6 +86,9 @@ namespace Eleia
         private static void Main(string[] args)
         {
             var opts = Parser.Default.ParseArguments<Options>(args).WithParsed(Configure);
+
+            if (!configured)
+                return;
 
             if (runOnce)
             {
@@ -153,6 +157,8 @@ namespace Eleia
                 ch.Login(username, password).Wait();
 
             runOnce = opts.RunOnce || timeBetweenUpdates == 0;
+
+            configured = true;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "RCS1090:Call 'ConfigureAwait(false)'.", Justification = "Not a library")]


### PR DESCRIPTION
Instead of using command line parameters to configuration, totally overhauled CLI interface! A set of parameters to set up configuration (but configuration file has a higher priority).

Add support for `--help` or `--version`,
Add also ability to run on a defined set of post ids.