### PR TITLE
Add serialization and deserialization of ids of already analyzed posts

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -285,6 +285,8 @@ namespace Eleia
                 return;
 
             analyzed.Add(post.id);
+            SaveAlreadyAnalyzed();
+
             if (IgnorePost(post))
                 return;
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -159,15 +159,22 @@ namespace Eleia
 
             if (!File.Exists(AnalyzedDatabasePath))
             {
-                analyzed = new HashSet<int>();
             }
             else
             {
                 logger.LogInformation("Loading already analyzed posts database.");
                 using (var fs = new FileStream(AnalyzedDatabasePath, FileMode.Open, FileAccess.Read))
                 {
-                    var formatter = new BinaryFormatter();
-                    analyzed = formatter.Deserialize(fs) as HashSet<int>;
+                    if (fs.Length == 0)
+                    {
+                        analyzed = new HashSet<int>();
+                        return;
+                    }
+                    else
+                    {
+                        var formatter = new BinaryFormatter();
+                        analyzed = formatter.Deserialize(fs) as HashSet<int>;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds serialization and deserialization of already analyzed post_ids to achieve some kind of persistency between runs (closes #4). Everything is saved into one file, `analyzed.bin`.

Database is also saved on Ctrl+C press.

There is also a commandline option `--ignoreAlreadyAnalyzed` which is ignoring loading and saving this database.